### PR TITLE
allow beta builds by setting a custom revision

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -46,7 +46,8 @@
     <build Condition="'$(BUILD_NUMBER)' != ''">$(BUILD_NUMBER)</build>
     <commit Condition="'$(GIT_COMMIT)' == ''">?</commit>
     <commit Condition="'$(GIT_COMMIT)' != ''">$(GIT_COMMIT)</commit>
-    <version>$(major).$(minor).$(revision).$(build)</version>
+    <version Condition="'$(BUILD_NUMBER)' != ''">$(major).$(minor).$(revision).$(build)</version>
+    <version Condition="'$(BUILD_NUMBER)' == ''">$(major).$(minor).$(revision)</version>
   </PropertyGroup>  
  
   <PropertyGroup>


### PR DESCRIPTION
Nuget does not support SemVer 2.0, so this is not conssidered a valid version: "$(major).$(minor).$(revision)-beta.$(build)".
This commit allows you to ignore the $(build) parameter, as this $(major).$(minor).$(revision)-beta is a valid version.